### PR TITLE
Proj6 features 

### DIFF
--- a/source/grib_api_io.silam.mod.f90
+++ b/source/grib_api_io.silam.mod.f90
@@ -677,7 +677,7 @@ MODULE grib_api_io
 
           corner_lon = corner_lon * ddeg_to_rad
           corner_lat = corner_lat * ddeg_to_rad
-          call lonalt2proj_pt(grGrid%proj4string, corner_lon, corner_lat, forwards)
+          call ll2proj_pt(grGrid%proj4string, corner_lon, corner_lat, forwards)
           !corner_lon  corner_lat are in projection units now (meters or degrees)
           grGrid%xmin = corner_lon
           grGrid%ymin = corner_lat
@@ -811,7 +811,7 @@ MODULE grib_api_io
      y3d(1:fs)=y(1:fs)
 
      ! projection returns radians
-     call lonalt2proj(grGrid%proj4string, x, y, fs, backwards)  
+     call ll2proj(grGrid%proj4string, x, y, fs, backwards)  
      ! now x is longitude in radian, y is latitude in radian
      xr(1:fs) = x(1:fs) * drad_to_deg
      yr(1:fs) = y(1:fs) * drad_to_deg
@@ -852,7 +852,7 @@ MODULE grib_api_io
      endif
       
      !rotations:  use x3d, y3d for shifted grid
-     call lonalt2proj(grGrid%proj4string, x3d, y3d, fs, backwards)
+     call ll2proj(grGrid%proj4string, x3d, y3d, fs, backwards)
      x3d(1:fs) = (x3d(1:fs) - x(1:fs)) * cos(y(1:fs))
      y3d(1:fs) = (y3d(1:fs) - y(1:fs)) 
      z3d(1:fs) = atan2(y3d(1:fs),x3d(1:fs)) !! map rotation angle

--- a/source/proj_silam.f90
+++ b/source/proj_silam.f90
@@ -4,17 +4,18 @@ module proj_silam
   !
 
   !$ use OMP_LIB
-  use, intrinsic :: ISO_C_BINDING, only: c_int, c_char, c_ptr, c_null_ptr, c_associated, c_size_t, c_loc, c_funptr, c_null_funptr,c_sizeof
+  use, intrinsic :: ISO_C_BINDING, only: c_int, c_char,c_double, c_ptr, c_null_ptr, c_associated, c_size_t, c_loc, c_funptr, c_null_funptr,c_sizeof
   use toolbox
 
   implicit none
   private
 
-  public lonalt2proj
-  public lonalt2proj_pt
+  !public proj_trans!(generalized)
+  public ll2proj
+  public ll2proj_pt
   public test_proj
 
-  private projFromStr
+  !private projFromStr
  
 #ifdef USE_PROJ6
    interface
@@ -48,7 +49,7 @@ module proj_silam
        type(c_ptr), value   :: pj
        integer(c_int),value :: dir
        type(c_ptr),value    :: x,y,z,t
-       integer(c_long),value:: sx,sy,sz,st
+       integer(c_int),value :: sx,sy,sz,st
        integer(c_int),value :: nx,ny,nz,nt
      end function
    end interface
@@ -67,7 +68,8 @@ module proj_silam
        IMPLICIT NONE
        integer(C_INT) :: pj_transform
        type(C_PTR), value :: src, dst
-       integer(C_LONG), value :: point_count
+       integer(C_INT), value :: point_count
+      ! integer(C_LONG), value :: point_count
        integer(C_INT), value :: point_offset
        type(C_PTR), value :: x, y, z
      end function pj_transform
@@ -76,146 +78,54 @@ module proj_silam
 #endif
 #endif
 
-  character (len=*), public, parameter :: lonlat_proj4="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs" !EPSG:4326
-
-
-
-
-  !!!! Registry of projections
-  integer, parameter :: max_nbr_of_projections = 10
-  integer :: nProjectionsKnown = int_missing
-  type(c_ptr), dimension(max_nbr_of_projections) ::  known_projection_ptr = c_null_ptr
-  character (len=fnlen), dimension(max_nbr_of_projections) :: known_projection_strings 
+character (len=*), public, parameter :: lonlat_proj4="+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs" !EPSG:4326
   
-  
+contains
 
-!  +o_lat_p=<latitude>
-!Latitude of the North pole of the unrotated source CRS, expressed in the rotated geographic CRS.
-!+o_lon_p=<longitude>
-!Longitude of the North pole of the unrotated source CRS, expressed in the rotated geographic CRS.
-!+lon_0=<value>
-!Longitude of projection center. (Defaults to 0.0)
- 
-
-  contains
-
-  integer function projFromStr(projstr)
-    !returns number of projection
-
-    character(len=*), intent(in) :: projstr
-    character (len=*), parameter :: sub_name='projFromStr'
-
-
-    integer :: iTmp
-
-#ifdef USE_PROJ4
-    projFromStr = int_missing
-    if (nProjectionsKnown < 1) then
-      !$OMP CRITICAL (proj_lock)
-      if (nProjectionsKnown < 1) then ! Ues, same check inside CRITICAL
-        known_projection_ptr(1) = pj_init_plus(lonlat_proj4//achar(0))
-        known_projection_strings(1) = lonlat_proj4
-        nProjectionsKnown = 1
-      endif
-      !$OMP END CRITICAL (proj_lock)
-      if (.not. c_associated(known_projection_ptr(1))) then
-        call set_error("pj_init_plus failed", sub_name)
-        return
-      endif
-    endif
-
-    do iTmp =  1, nProjectionsKnown
-      if (known_projection_strings(iTmp) == projstr) exit
-    enddo
-
-
-    if (iTmp <=  nProjectionsKnown) then
-      projFromStr = iTmp
-      return
-    endif
-
-    !$OMP CRITICAL (proj_lock)
-      do iTmp =  iTmp, nProjectionsKnown !!Could appear by now
-        if (known_projection_strings(iTmp) == projstr) exit
-      enddo
-
-      if (iTmp <=  nProjectionsKnown) then !! Appeared while we were waiting for proj_lock
-        projFromStr = iTmp
-      elseif (iTmp > max_nbr_of_projections) then
-
-        call msg_warning ("max_nbr_of_projections exceeded"//fu_str(max_nbr_of_projections), &
-                                                                & sub_name)
-        call msg("Projections registered so far:")
-        do iTmp =  1, nProjectionsKnown
-          call msg('"'//trim(known_projection_strings(iTmp))//'"')
-        enddo
-        call set_error ("max_nbr_of_projections exceeded", sub_name)
-
-      else
-        known_projection_ptr(iTmp) = pj_init_plus(trim(projstr)//achar(0))
-        if (c_associated(known_projection_ptr(iTmp))) then
-          known_projection_strings(iTmp) = trim(projstr)
-          nProjectionsKnown = iTmp
-          projFromStr = iTmp
-        else
-          call set_error("pj_init_plus failed", sub_name)
-        endif
-      endif
-    !$OMP END CRITICAL (proj_lock)
-#else
-  call set_error("compiled without USE_PROJ4", sub_name)
-#endif    
-  end function projFromStr
-
-
-  !******************************************************************
-
-  subroutine lonalt2proj(projstr, x, y, point_count, direction)
-
+subroutine proj_trans(s_srs,t_srs, x, y, np, direction)
     !
-    ! Projects in-place lon and lat to projection
+    !"Any 2 any" coordinate system transofmration:
+    ! Projects IN-PLACE arrays of coordinates from one projection to another.
     !
     implicit none
-    character(len=*), intent(in) :: projstr 
-    integer, intent(in) :: point_count !! length of x and y
-    integer, intent(in) :: direction
-    real(8), dimension (:), target, intent(inout) :: x, y !! projection x,y on input, lon,lat on output
-    character (len=*), parameter :: sub_name='lonalt2proj'
-
-    integer :: projno, iStat
-    integer(8) :: lcount
-
+    character(len=*), intent(in) :: s_srs,t_srs           !source & target spatial reference system (srs) (proj4str, epsgs, wkt, etc.)
+    integer, intent(in) :: np                             ! number of points (length of x or y)
+    integer, intent(in) :: direction                      ! forward / backwards
+    real(8), dimension (:), target, intent(inout) :: x, y ! coordinates to transform
+    character (len=*), parameter :: sub_name='proj_trans'
+    
 #ifdef USE_PROJ6
   type(c_ptr) :: CTX = c_null_ptr
   type(c_ptr) ::  PJ = c_null_ptr
-  integer     :: dir
-  integer(8)  :: sp         !size (in bytes of coordinates datatype)
+  type(c_ptr) ::  area= c_null_ptr
+  integer     :: dir, iStat
+  integer     :: sp              !size (in bytes of coordinates datatype)
 
   print*,"Usando PROJ6.."  
-  CTX=proj_context_create()
-  PJ=proj_create_crs_to_crs(CTX, lonlat_proj4, &
-                            &    projstr//achar(0)     , C_NULL_PTR)
 
-     if   ( direction == forwards ) then
+  CTX=proj_context_create()
+  PJ=proj_create_crs_to_crs(CTX, trim(s_srs)//achar(0),           &
+                           &     trim(t_srs)//achar(0), C_NULL_PTR)
+
+  if      ( direction == forwards ) then
      dir=1;
   else if ( direction == backwards) then
      dir=-1;
-  !else if ( direction == identity ) then
-  !   dir=0;
   else
-    call set_error("Unknown direction: "//fu_str(direction),sub_name)
-    return
+     call set_error("Unknown direction: "//fu_str(direction),sub_name)
+     return
   endif
 
-  sp=c_sizeof(x(1))
-  iStat=proj_trans_generic( PJ, dir,                        &
-                          & c_loc(x(1)), sp, point_count,   &
-                          & c_loc(y(1)), sp, point_count,   &
-                          & c_null_ptr , sp, 0,             &
-                          & c_null_ptr , sp, 0)
-  !if (iStat /= 0) then                             
-  !  call set_error("pj_transform failed",sub_name)
-  !endif
+  sp=c_sizeof(x(1))         !Step length (bytes) between consecutive elements of the array
+  iStat=proj_trans_generic( PJ, dir,             &
+                          & c_loc(x)   , sp, np, &
+                          & c_loc(y)   , sp, np, &
+                          & C_NULL_PTR ,  0, 0 , &
+                          & C_NULL_PTR ,  0, 0  )
+  if (iStat /= np) then                             
+    print*,"Number of transformations failed = ",np-iStat
+    call set_error("proj_trans_generic failed",sub_name)
+  endif
 
   !Clean:
   call proj_destroy(PJ)
@@ -223,26 +133,22 @@ module proj_silam
 
 #else
 #ifdef USE_PROJ4 
+   integer     :: iStat
+   type(c_ptr) :: PJ1 = c_null_ptr
+   type(c_ptr) :: PJ2 = c_null_ptr
+
    print*,"Usando PROJ4.."  
 
    x=x*ddeg_to_rad  !convert degrees to radians
    y=y*ddeg_to_rad  !convert degrees to radians
 
-   lcount = point_count
-   projno = projFromStr(projstr)
-   if (error) then
-     call msg("projFromStr failed for:")
-     call msg('"'//trim(projstr)//'"')
-     call set_error("projFromStr failed", sub_name)
-     return
-   endif
-   
+   PJ1= pj_init_plus(trim(s_srs)//achar(0))
+   PJ2= pj_init_plus(trim(t_srs)//achar(0))
+
    if (direction == forwards) then
-     iStat = pj_transform(known_projection_ptr(1), known_projection_ptr(projno), &
-                 &   lcount, 1, C_LOC(x(1)), C_LOC(y(1)), C_NULL_PTR)
+      iStat = pj_transform(PJ1, PJ2, np, 1, C_LOC(x), C_LOC(y), C_NULL_PTR)
    elseif (direction == backwards) then
-     iStat = pj_transform(known_projection_ptr(projno), known_projection_ptr(1), &
-                 &   lcount, 1, C_LOC(x(1)), C_LOC(y(1)), C_NULL_PTR)
+      iStat = pj_transform(PJ2, PJ1, np, 1, C_LOC(x), C_LOC(y), C_NULL_PTR)
    else
      call set_error("Unknown direction: "//fu_str(direction),sub_name)
      return
@@ -253,101 +159,119 @@ module proj_silam
    x=x*drad_to_deg     !return to degrees!
    y=y*drad_to_deg     !return to degrees!
 
-
 #else
-     call set_error("compiled without USE_PROJ4", sub_name)
-     !
+     call set_error("compiled without USE_PROJ4 nor USE_PROJ6", sub_name)
      ! FIXME Handling of rotated lon-lat should be here
-     !
 #endif
 #endif
-  end subroutine lonalt2proj
+end subroutine
 
-  subroutine lonalt2proj_pt(projstr, x, y, direction)
-    !! HUOM!!! pj_transform treats all angles in radians!
 
+
+!!WRAPERS!!
+! Subroutines to handle latlon (ll) transformations and single value transformation
+
+!ll2proj:
+  subroutine ll2proj(t_srs, x, y, np, direction)
     !
-    ! Projects in-place lon and lat to projection
-    !
-
-    character(len=*), intent(in) :: projstr 
-    integer, intent(in) :: direction
-    real(8), intent(inout), target :: x, y !! projection x,y on input, lon,lat on output
-    character (len=*), parameter :: sub_name='lonalt2proj'
-    integer(8), parameter :: one = 1
-
-    integer :: projno, iStat
-
-
-#ifdef USE_PROJ4 
-    projno = projFromStr(projstr)
-    if (error) then
-      call msg("projFromStr failed for:")
-      call msg('"'//trim(projstr)//'"')
-      call set_error("projFromStr failed", sub_name)
-      return
-    endif
-
-    if (direction == forwards) then
-      iStat = pj_transform(known_projection_ptr(1), known_projection_ptr(projno), &
-                  &   one, 1, C_LOC(x), C_LOC(y), C_NULL_PTR)
-    elseif (direction == backwards) then
-      iStat = pj_transform(known_projection_ptr(projno), known_projection_ptr(1), &
-                  &   one, 1, C_LOC(x), C_LOC(y), C_NULL_PTR)
-    else
-      call set_error("Unknown direction: "//fu_str(direction),sub_name)
-      return
-    endif
-    if (iStat /= 0) then
-      call set_error("pj_transform failed",sub_name)
-    endif
-#else
-  call set_error("compiled without USE_PROJ4", sub_name)
-  !
-  ! FIXME Handling of rotated lon-lat bypassing proj should be here
-  !
-#endif
-
-  end subroutine lonalt2proj_pt
-
-
-
-  subroutine test_proj()
+    ! Projects in-place lon and lat to any other projection
     implicit none
+    character(len=*), intent(in) :: t_srs !source & target spatial reference system (srs) (proj4str, epsgs, wkt, etc.)
+    integer, intent(in) :: np             ! number of points (length of x or y)
+    integer, intent(in) :: direction      ! forward / backwards
+    real(8), dimension (:), target, intent(inout) :: x, y ! coordinates to transform
+    character (len=*), parameter :: sub_name='ll2proj'
+    call proj_trans(lonlat_proj4,t_srs,x,y,np,direction)
+  end subroutine
 
-    integer, parameter :: np = 4
-    real(8), dimension(np) :: lats, lons
-    integer :: i
+!ll2proj_pt:
+  subroutine ll2proj_pt(t_srs, x, y, direction)
+    !      
+    ! same that ll2proj but for a single value
+    implicit none
+    character(len=*), intent(in) :: t_srs  !source & target spatial reference system (srs) (proj4str, epsgs, wkt, etc.)
+    integer, intent(in) :: direction       !forward / backwards
+    real(8), target, intent(inout) :: x, y !coordinates to transform
+    real(8), dimension(1) :: xa, ya        !coordinates to transform (rank-1 array form)
+    character (len=*), parameter :: sub_name='ll2proj_pt'
+    xa=x;ya=y
+    call proj_trans(lonlat_proj4,t_srs,xa,ya,1,direction)
+    x=xa(1);y=ya(1)
+  end subroutine
+!ll2proj_pt:
+  subroutine proj_trans_pt(s_srs, t_srs, x, y, direction)
+    !      
+    ! same that ll2proj but for a single value
+    implicit none
+    character(len=*), intent(in) :: s_srs, t_srs  !source & target spatial reference system (srs) (proj4str, epsgs, wkt, etc.)
+    integer, intent(in) :: direction       !forward / backwards
+    real(8), target, intent(inout) :: x, y !coordinates to transform
+    real(8), dimension(1) :: xa, ya        !coordinates to transform (rank-1 array form)
+    character (len=*), parameter :: sub_name='ll2proj_pt'
+    xa=x;ya=y
+    call proj_trans(s_srs,t_srs,xa,ya,1,direction)
+    x=xa(1);y=ya(1)
+  end subroutine
 
-    character (len=*), parameter :: hirlam_rll_proj4 = "+proj=ob_tran +o_proj=longlat +o_lon_p=0 +o_lat_p=30 +lon_0=0"
-    character (len=*), parameter :: lcc_example="+proj=lcc +lon_0=-90 +lat_1=33 +lat_2=45"
+!TEST:
+  subroutine test_proj()
+     implicit none
 
-    !! corners of EU meteo in projected lon-lat
-    lons(1:np) = (/-26., -26., 40., 40./)  
-    lats(1:np) = (/-35., 22.5, 22.5, -35./)
+     integer, parameter :: np = 4
+     real(8), dimension(np) :: lats, lons
+     integer :: i
+     real(8) :: x, y
+     character (len=*), parameter :: hirlam_rll_proj4 ="+proj=ob_tran +o_proj=longlat +o_lon_p=0 +o_lat_p=30 +lon_0=0"
+     character (len=*), parameter ::       lcc_example="+proj=lcc  +lon_0=-90 +lat_1=33 +lat_2=45"
+     character (len=*), parameter ::      merc_example="+proj=merc +lon_0=-90 +lat_1=33 +lat_2=45"
 
-    call msg("rotated-pole coordinates lon, lat")
-    call msg(hirlam_rll_proj4)
-    do i=1,np
-      call msg(fu_str(i), lons(i),lats(i))
-    enddo
+     !! corners of EU meteo in projected lon-lat
+     lons(1:np) = (/-26., -26., 40., 40./)  
+     lats(1:np) = (/-35., 22.5, 22.5, -35./)
 
-    call lonalt2proj(hirlam_rll_proj4, lons, lats, np, backwards)
+     call msg("rotated-pole coordinates lon, lat")
+     call msg(hirlam_rll_proj4)
+     do i=1,np
+       call msg(fu_str(i), lons(i),lats(i))
+     enddo
 
-    call msg("Same in WGS84 coordinates lon, lat")
-    call msg(lonlat_proj4)
-    do i=1,np
-      call msg(fu_str(i), lons(i),lats(i))
-    enddo
+     call ll2proj(hirlam_rll_proj4, lons, lats, np, backwards)
 
-    call lonalt2proj(hirlam_rll_proj4, lons, lats, np, forwards)
+     call msg("Same in WGS84 coordinates lon, lat")
+     call msg(lonlat_proj4)
+     do i=1,np
+       call msg(fu_str(i), lons(i),lats(i))
+     enddo
 
-    call msg("And back! lon, lat")
-    call msg(hirlam_rll_proj4)
-    do i=1,np
-      call msg(fu_str(i), lons(i),lats(i))
-    enddo
-    call msg("Done")
+     call ll2proj(hirlam_rll_proj4, lons, lats, np, forwards)
+
+     call msg("And back! lon, lat")
+     call msg(hirlam_rll_proj4)
+     do i=1,np
+       call msg(fu_str(i), lons(i),lats(i))
+     enddo
+     call msg("Done")
+
+     !Aditional test: single value
+     print*,"(t) Aditional test 1: single value transformation.."
+     x=lons(1); y=lats(1)
+     print*,"original lons(1),y=lats(1) ",lons(1),lats(1)
+     call ll2proj_pt(hirlam_rll_proj4,x,y,backwards)
+     print*,"transformed to x,y         ",x,y
+     call ll2proj_pt(hirlam_rll_proj4,x,y,forwards)
+     print*,"back to lons(1),y=lats(1): ",x,y
+     call msg("Done")
+
+     !Aditional test: any 2 any
+     print*,"(t) Aditional test 2: any to any transformation.."
+     
+     print*,"Original lons(1),y=lats(1) ",lons(1),lats(1)
+     x=lons(1); y=lats(1)
+     call proj_trans_pt(hirlam_rll_proj4, lcc_example, x, y, forwards )
+     print*,"transformed to lcc         ",x,y
+     call proj_trans_pt(hirlam_rll_proj4, lcc_example, x, y, backwards)
+     print*,"back to lons(1),y=lats(1): ",x,y
+     call msg("Done")
 
   end subroutine test_proj
 

--- a/source/proj_silam.f90
+++ b/source/proj_silam.f90
@@ -10,7 +10,8 @@ module proj_silam
   implicit none
   private
 
-  !public proj_trans!(generalized)
+  public proj_trans   
+  public proj_trans_pt
   public ll2proj
   public ll2proj_pt
   public test_proj
@@ -73,7 +74,6 @@ module proj_silam
        integer(C_INT), value :: point_offset
        type(C_PTR), value :: x, y, z
      end function pj_transform
-  
    end interface
 #endif
 #endif
@@ -97,11 +97,10 @@ subroutine proj_trans(s_srs,t_srs, x, y, np, direction)
 #ifdef USE_PROJ6
   type(c_ptr) :: CTX = c_null_ptr
   type(c_ptr) ::  PJ = c_null_ptr
-  type(c_ptr) ::  area= c_null_ptr
   integer     :: dir, iStat
   integer     :: sp              !size (in bytes of coordinates datatype)
 
-  print*,"Usando PROJ6.."  
+  call msg("Usando PROJ6..") 
 
   CTX=proj_context_create()
   PJ=proj_create_crs_to_crs(CTX, trim(s_srs)//achar(0),           &
@@ -123,7 +122,7 @@ subroutine proj_trans(s_srs,t_srs, x, y, np, direction)
                           & C_NULL_PTR ,  0, 0 , &
                           & C_NULL_PTR ,  0, 0  )
   if (iStat /= np) then                             
-    print*,"Number of transformations failed = ",np-iStat
+    print*,"Warning! Number of transformations failed = ",np-iStat
     call set_error("proj_trans_generic failed",sub_name)
   endif
 
@@ -137,7 +136,7 @@ subroutine proj_trans(s_srs,t_srs, x, y, np, direction)
    type(c_ptr) :: PJ1 = c_null_ptr
    type(c_ptr) :: PJ2 = c_null_ptr
 
-   print*,"Usando PROJ4.."  
+  call msg("Usando PROJ4..") 
 
    x=x*ddeg_to_rad  !convert degrees to radians
    y=y*ddeg_to_rad  !convert degrees to radians
@@ -156,6 +155,7 @@ subroutine proj_trans(s_srs,t_srs, x, y, np, direction)
    if (iStat /= 0) then
      call set_error("pj_transform failed",sub_name)
    endif
+
    x=x*drad_to_deg     !return to degrees!
    y=y*drad_to_deg     !return to degrees!
 
@@ -198,7 +198,7 @@ end subroutine
     call proj_trans(lonlat_proj4,t_srs,xa,ya,1,direction)
     x=xa(1);y=ya(1)
   end subroutine
-!ll2proj_pt:
+!proj_trans_pt:
   subroutine proj_trans_pt(s_srs, t_srs, x, y, direction)
     !      
     ! same that ll2proj but for a single value


### PR DESCRIPTION
HI, 

Here i include support for PROJ > v.6. (remember to define `-D USE_PROJ6` on your Fortran's FLAGS)

I included a new function called **`proj_trans`**  (and its corresponding *`proj_trans_pt`*)  it does coordinate transformations from "any to any" system. This is now the "main" function for coordinate transformations. I just have relegate all the others ones to be a "special case" of `proj_trans`, so we have less stuff to debug in the future.

I did some renaming:
 +  lonalt2proj      -> ll2proj
+  lonalt2proj_pt  -> ll2proj_pt 

> **WARNING**: Now  `ll2proj` takes coordinates in *decimal degrees* (not anymore in *radians*, so be carefull!) 

Also I did a little bit of cleaning, and add some extra tests.
  
You're welcome! XD